### PR TITLE
fix: license path from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,7 @@ Write to us at `help@litlyx.com` if you need to contact us.
 
 # License
 
-Litlyx is licensed under the [Apache 2.0](/LICENSE.md) license.
+Litlyx is licensed under the [Apache 2.0](/LICENSE) license.
 
 # Share some ❤️ for the repo
 


### PR DESCRIPTION
The path to the LICENSE from the README was wrong and getting me to a 404 error page. Another option would be to convert the LICENSE to a markdown file.