### PR TITLE
Use interpolation for environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - "6379:6379"
     environment:
-      REDIS_USERNAME: ${REDIS_USER:-}
+      REDIS_USERNAME: ${REDIS_USER:-default}
       REDIS_PASSWORD: ${REDIS_PASS:?}
     volumes:
       - redis_data:/data
@@ -34,7 +34,7 @@ services:
       - MONGO_CONNECTION_STRING=mongodb://${MONGO_ROOT_USER:-root}:${MONGO_ROOT_PASS:?}@mongo:27017/Litlyx?authSource=admin
       - STREAM_NAME=LITLYX_STREAM
       - REDIS_URL=redis://redis:6379
-      - REDIS_USERNAME=${REDIS_USER:-}
+      - REDIS_USERNAME=${REDIS_USER:-default}
       - REDIS_PASSWORD=${REDIS_PASS:?}
     depends_on:
       - mongo
@@ -49,7 +49,7 @@ services:
       - MONGO_CONNECTION_STRING=mongodb://${MONGO_ROOT_USER:-root}:${MONGO_ROOT_PASS:?}@mongo:27017/Litlyx?authSource=admin
       - STREAM_NAME=LITLYX_STREAM
       - REDIS_URL=redis://redis:6379
-      - REDIS_USERNAME=${REDIS_USER:-}
+      - REDIS_USERNAME=${REDIS_USER:-default}
       - REDIS_PASSWORD=${REDIS_PASS:?}
       - GROUP_NAME=DATABASE
     depends_on:
@@ -64,7 +64,7 @@ services:
       - NUXT_LICENSE_KEY=${LICENSE_KEY:-}
       - NUXT_MONGO_CONNECTION_STRING=mongodb://${MONGO_ROOT_USER:-root}:${MONGO_ROOT_PASS:?}@mongo:27017/Litlyx?authSource=admin
       - NUXT_REDIS_URL=redis://redis:6379
-      - NUXT_REDIS_USERNAME=${REDIS_USER:-}
+      - NUXT_REDIS_USERNAME=${REDIS_USER:-default}
       - NUXT_REDIS_PASSWORD=${REDIS_PASS:?}
       - NUXT_BASE_URL=http://127.0.0.1:3000
       - NUXT_SESSION_PASSWORD=${JWT_SECRET:?}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,20 +6,20 @@ services:
     ports:
       - "27017:27017"
     environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: mongo_password_here
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USER:-root}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASS:?}
     volumes:
       - mongo_data:/data/db
 
   redis:
     image: redis:7
     restart: always
-    command: ["redis-server", "--requirepass", "redis_password_here"]
+    command: ["redis-server", "--requirepass", "${REDIS_PASS:?}"]
     ports:
       - "6379:6379"
     environment:
-      REDIS_USERNAME: default
-      REDIS_PASSWORD: redis_password_here
+      REDIS_USERNAME: ${REDIS_USER:-}
+      REDIS_PASSWORD: ${REDIS_PASS:?}
     volumes:
       - redis_data:/data
 
@@ -31,11 +31,11 @@ services:
       - PORT=3001
       - DEV_MODE=false
       - EMAIL_TRPC_URL=none
-      - MONGO_CONNECTION_STRING=mongodb://root:mongo_password_here@mongo:27017/Litlyx?authSource=admin
+      - MONGO_CONNECTION_STRING=mongodb://${MONGO_ROOT_USER:-root}:${MONGO_ROOT_PASS:?}@mongo:27017/Litlyx?authSource=admin
       - STREAM_NAME=LITLYX_STREAM
       - REDIS_URL=redis://redis:6379
-      - REDIS_USERNAME=default
-      - REDIS_PASSWORD=redis_password_here
+      - REDIS_USERNAME=${REDIS_USER:-}
+      - REDIS_PASSWORD=${REDIS_PASS:?}
     depends_on:
       - mongo
       - redis
@@ -46,11 +46,11 @@ services:
       - DEV_MODE=false
       - EMAIL_TRPC_URL=none
       - EMAIL_SECRET=none
-      - MONGO_CONNECTION_STRING=mongodb://root:mongo_password_here@mongo:27017/Litlyx?authSource=admin
+      - MONGO_CONNECTION_STRING=mongodb://${MONGO_ROOT_USER:-root}:${MONGO_ROOT_PASS:?}@mongo:27017/Litlyx?authSource=admin
       - STREAM_NAME=LITLYX_STREAM
       - REDIS_URL=redis://redis:6379
-      - REDIS_USERNAME=default
-      - REDIS_PASSWORD=redis_password_here
+      - REDIS_USERNAME=${REDIS_USER:-}
+      - REDIS_PASSWORD=${REDIS_PASS:?}
       - GROUP_NAME=DATABASE
     depends_on:
       - mongo
@@ -61,15 +61,15 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - NUXT_LICENSE_KEY=YOUR_LICENSE_KEY_HERE
-      - NUXT_MONGO_CONNECTION_STRING=mongodb://root:mongo_password_here@mongo:27017/Litlyx?authSource=admin
+      - NUXT_LICENSE_KEY=${LICENSE_KEY:-}
+      - NUXT_MONGO_CONNECTION_STRING=mongodb://${MONGO_ROOT_USER:-root}:${MONGO_ROOT_PASS:?}@mongo:27017/Litlyx?authSource=admin
       - NUXT_REDIS_URL=redis://redis:6379
-      - NUXT_REDIS_USERNAME=default
-      - NUXT_REDIS_PASSWORD=redis_password_here
+      - NUXT_REDIS_USERNAME=${REDIS_USER:-}
+      - NUXT_REDIS_PASSWORD=${REDIS_PASS:?}
       - NUXT_BASE_URL=http://127.0.0.1:3000
-      - NUXT_SESSION_PASSWORD=jwt_secret_here_for_authentication
-      - NUXT_ADMIN_EMAIL=test@admin.admin
-      - NUXT_ADMIN_PASSWORD=passwordadmin
+      - NUXT_SESSION_PASSWORD=${JWT_SECRET:?}
+      - NUXT_ADMIN_EMAIL=${ADMIN_EMAIL:?}
+      - NUXT_ADMIN_PASSWORD=${ADMIN_PASS:?}
       - NUXT_PUBLIC_SELFHOSTED=true
       - NUXT_PUBLIC_AI_ENABLED=false # change to TRUE if you've provided AI keys down below
       # NUXT_AI_ORG=your_openai_org_id


### PR DESCRIPTION
This could probably be expanded upon, but here I used docker's interpolation to allow for variables in the compose file. This enables projects like Coolify to be able to override the values and deploy this project without someone having to fork the repo.